### PR TITLE
init pyproject support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: check-yaml
+        language_version: python3.10
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/adrienverge/yamllint.git

--- a/action.yaml
+++ b/action.yaml
@@ -53,8 +53,8 @@ runs:
     - id: install-from-pyproject-toml
       if: ${{ inputs.pyproject-toml-path != '' }}
       run: |
-        pip install poetry
-        poetry install --no-dev --no-root -f ${{ inputs.pyproject-toml-path }}
+        cd $(dirname ${{ inputs.pyproject-toml-path }})
+        pip install .
       shell: bash
 
     - id: prefect-deploy

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,3 @@
----
 name: Deploy a Prefect flow
 author: PrefectHQ
 description: Deploy a flow from a project by creating a Prefect deployment.
@@ -23,6 +22,15 @@ inputs:
       example './flow1/requirements.txt,./flow2/requirements.txt'
     required: false
     default: ''
+
+  pyproject-toml-path:
+    description:
+      Path to your pyproject.toml file for
+      dependency management of your Prefect flow(s).
+      example './pyproject.toml'
+    required: false
+    default: ''
+
   all-deployments:
     description:
       If set to true, all deployments will be
@@ -40,6 +48,13 @@ runs:
         for req in ${requirements_paths[@]}; do
           pip install -r $req
         done
+      shell: bash
+
+    - id: install-from-pyproject-toml
+      if: ${{ inputs.pyproject-toml-path != '' }}
+      run: |
+        pip install poetry
+        poetry install --no-dev --no-root -f ${{ inputs.pyproject-toml-path }}
       shell: bash
 
     - id: prefect-deploy

--- a/examples/actions/install-deps-via-pyproject.yaml
+++ b/examples/actions/install-deps-via-pyproject.yaml
@@ -20,7 +20,7 @@ jobs:
           prefect-workspace: ${{ secrets.PREFECT_WORKSPACE }}
 
       - name: Run Prefect Deploy
-        uses: PrefectHQ/actions-prefect-deploy@pyproject
+        uses: PrefectHQ/actions-prefect-deploy
         with:
           deployment-names: Simple
           pyproject-toml-path: ./path/to/pyproject.toml

--- a/examples/actions/install-deps-via-pyproject.yaml
+++ b/examples/actions/install-deps-via-pyproject.yaml
@@ -1,0 +1,26 @@
+name: Deploy a Prefect flow (installing dependencies from pyproject.toml)
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy_flow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Prefect Auth
+        uses: PrefectHQ/actions-prefect-auth@v1
+        with:
+          prefect-api-key: ${{ secrets.PREFECT_API_KEY }}
+          prefect-workspace: ${{ secrets.PREFECT_WORKSPACE }}
+
+      - name: Run Prefect Deploy
+        uses: PrefectHQ/actions-prefect-deploy@pyproject
+        with:
+          deployment-names: Simple
+          pyproject-toml-path: ./path/to/pyproject.toml


### PR DESCRIPTION
adds ability to specify a `pyproject.toml` to install deps before deployment creation instead of only requirements.txt

## Example
```yaml
name: Deploy a Prefect flow
on:
  push:
    branches:
      - main
jobs:
  deploy_flow:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3

      - uses: actions/setup-python@v4
        with:
          python-version: '3.10'

      - name: Prefect Auth
        uses: PrefectHQ/actions-prefect-auth@v1
        with:
          prefect-api-key: ${{ secrets.PREFECT_API_KEY }}
          prefect-workspace: ${{ secrets.PREFECT_WORKSPACE }}

      - name: Run Prefect Deploy
        uses: PrefectHQ/actions-prefect-deploy@v3
        with:
          deployment-names: Simple
          pyproject-toml-path: ./path/to/pyproject.toml

```

Resolves https://github.com/PrefectHQ/actions-prefect-deploy/issues/28