### PR TITLE
Chore/add automated release or update of major GHA version

### DIFF
--- a/.github/workflows/create-update-release.yaml
+++ b/.github/workflows/create-update-release.yaml
@@ -7,7 +7,7 @@ on:
       - 'v*.*.*'
 permissions: {}
 jobs:
-  release:
+  update-create-major-version:
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -30,3 +30,5 @@ jobs:
             git push origin ${MAJOR_VERSION}
             gh release create --title "${MAJOR_VERSION}" --generate-notes --target "${RELEASE_SHA} --latest"
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-update-release.yaml
+++ b/.github/workflows/create-update-release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Release Major Version
+      - name: Release or UpdateMajor Version
         run: |
           export MAJOR_VERSION=$(echo ${{ github.ref_name }} | cut -d '.' -f 1)
           echo "Releasing major version ${MAJOR_VERSION}"

--- a/.github/workflows/create-update-release.yaml
+++ b/.github/workflows/create-update-release.yaml
@@ -17,9 +17,12 @@ jobs:
           echo "Releasing major version ${MAJOR_VERSION}"
           if git show-ref --tags --verify --quiet "refs/tags/${MAJOR_VERSION}"; then
             echo "Tag ${MAJOR_VERSION} exists, bumping to match with the latest release"
+            git tag ${MAJOR_VERSION} -f
+            git push origin ${MAJOR_VERSION} -f
           else
             echo "Tag ${MAJOR_VERSION} does not exist. Creating a new tag and release."
+            export RELEASE_SHA=$(git rev-parse HEAD)
             git tag "${MAJOR_VERSION}"
-            git push origin --tags
-            gh release create --title "${MAJOR_VERSION}" --generate-notes --target "${MAJOR_VERSION} --latest"
+            git push origin ${MAJOR_VERSION}
+            gh release create --title "${MAJOR_VERSION}" --generate-notes --target "${RELEASE_SHA} --latest"
           fi

--- a/.github/workflows/create-update-release.yaml
+++ b/.github/workflows/create-update-release.yaml
@@ -28,7 +28,7 @@ jobs:
             export RELEASE_SHA=$(git rev-parse HEAD)
             git tag "${MAJOR_VERSION}"
             git push origin ${MAJOR_VERSION}
-            gh release create --title "${MAJOR_VERSION}" --generate-notes --target "${RELEASE_SHA} --latest"
+            gh release create --title "${MAJOR_VERSION}" --generate-notes --target "${RELEASE_SHA}" --latest
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-update-release.yaml
+++ b/.github/workflows/create-update-release.yaml
@@ -8,6 +8,8 @@ on:
 permissions: {}
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/create-update-release.yaml
+++ b/.github/workflows/create-update-release.yaml
@@ -26,9 +26,7 @@ jobs:
           else
             echo "Tag ${MAJOR_VERSION} does not exist. Creating a new tag and release."
             export RELEASE_SHA=$(git rev-parse HEAD)
-            git tag "${MAJOR_VERSION}"
-            git push origin ${MAJOR_VERSION}
-            gh release create --title "${MAJOR_VERSION}" --generate-notes --target "${RELEASE_SHA}" --latest
+            gh release create "${MAJOR_VERSION}" --title "${MAJOR_VERSION}" --generate-notes --target "${RELEASE_SHA}" --latest
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-update-release.yaml
+++ b/.github/workflows/create-update-release.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Release Major Version
         run: |
           export MAJOR_VERSION=$(echo ${{ github.ref_name }} | cut -d '.' -f 1)

--- a/.github/workflows/create-update-release.yaml
+++ b/.github/workflows/create-update-release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Release or UpdateMajor Version
+      - name: Release or Update Major Version
         run: |
           export MAJOR_VERSION=$(echo ${{ github.ref_name }} | cut -d '.' -f 1)
           echo "Releasing major version ${MAJOR_VERSION}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+---
+name: Update Major Version of Prefect Deploy Action
+on:
+  push:
+    tags:
+      # Match the version format to not catch vx major releases
+      - 'v*.*.*'
+permissions: {}
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Release Major Version
+        run: |
+          export MAJOR_VERSION=$(echo ${{ github.ref_name }} | cut -d '.' -f 1)
+          echo "Releasing major version ${MAJOR_VERSION}"
+          if git show-ref --tags --verify --quiet "refs/tags/${MAJOR_VERSION}"; then
+            echo "Tag ${MAJOR_VERSION} exists, bumping to match with the latest release"
+          else
+            echo "Tag ${MAJOR_VERSION} does not exist. Creating a new tag and release."
+            gh release create --title "${MAJOR_VERSION}" --generate-notes --target "${MAJOR_VERSION} --latest"
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,5 +19,7 @@ jobs:
             echo "Tag ${MAJOR_VERSION} exists, bumping to match with the latest release"
           else
             echo "Tag ${MAJOR_VERSION} does not exist. Creating a new tag and release."
+            git tag "${MAJOR_VERSION}"
+            git push origin --tags
             gh release create --title "${MAJOR_VERSION}" --generate-notes --target "${MAJOR_VERSION} --latest"
           fi

--- a/README.md
+++ b/README.md
@@ -196,5 +196,8 @@ jobs:
           PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
 ```
 
+## Releasing the Action
+Manually create a new semver release (i.e `v1.0.0`) against a new tag to trigger the release workflow.  This workflow will update the major version of the action (i.e `v1`) to point to the new semver release.
+
 ## Terms & Conditions
 See here for the Prefect's [Terms and Conditions](https://www.prefect.io/legal/terms/).


### PR DESCRIPTION
- Resolves: https://linear.app/prefect/issue/PLA-706/automate-actions-prefect-deploy-release-updates
- Goal of this PR is to automatically repoint or create a new major version of the github action when a semver release is created.
- In the event that the semver release is just a minor or patch bump of the action, we will repoint the major version i.e v1 to point to that semver sha
- In the event that a new major release occurs i.e 5.0.0, this action will automatically create a release for the major version i.e v5