### PR TITLE
chore/Add release script and update gha to pull the latest release vs tag

### DIFF
--- a/.github/workflows/create-update-release.yaml
+++ b/.github/workflows/create-update-release.yaml
@@ -26,7 +26,7 @@ jobs:
           else
             echo "Tag ${MAJOR_VERSION} does not exist. Creating a new tag and release."
             export RELEASE_SHA=$(git rev-parse HEAD)
-            gh release create "${MAJOR_VERSION}" --title "${MAJOR_VERSION}" --generate-notes --target "${RELEASE_SHA}" --latest
+            gh release create "${MAJOR_VERSION}" --title "${MAJOR_VERSION}" --generate-notes --target "${RELEASE_SHA}" --latest=false
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/release
+++ b/scripts/release
@@ -19,7 +19,7 @@ with tempfile.TemporaryDirectory() as temporary:
         version = f"v{int(latest_version.split('.')[0].split('v')[1]) + 1}.0.0"
     elif release_type == "minor":
         version = f"{latest_version.split('.')[0]}.{int(latest_version.split('.')[1]) + 1}.0"
-    else:
+    elif release_type == "patch":
         version = f"{latest_version.split('.')[0]}.{latest_version.split('.')[1]}.{int(latest_version.split('.')[2]) + 1}"
 
 print()

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import subprocess
+import tempfile
+
+CLONE_URL = "https://github.com/PrefectHQ/actions-prefect-deploy"
+
+release_type = input("Is this a major, minor, or patch release? ")
+# Clone the repo and get the latest version on the default branch
+# Then determine the new version based on latest tag and release type
+with tempfile.TemporaryDirectory() as temporary:
+    subprocess.check_call(["git", "clone", "--bare", CLONE_URL, temporary])
+    print()
+    result = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=temporary)
+    new_revision = result.decode().strip()
+    # Need to get the latest release as the tag for the major version tends to be the latest tagged version.
+    latest_version = subprocess.check_output(["gh", "release", "list", "--json", "name,isLatest", "--jq", ".[] | select(.isLatest) | .name"]).decode("utf-8")
+    print(f"The current version of Actions Prefect Deploy is {latest_version}")
+    if release_type == "major":
+        version = f"v{int(latest_version.split('.')[0].split('v')[1]) + 1}.0.0"
+    elif release_type == "minor":
+        version = f"{latest_version.split('.')[0]}.{int(latest_version.split('.')[1]) + 1}.0"
+    else:
+        version = f"{latest_version.split('.')[0]}.{latest_version.split('.')[1]}.{int(latest_version.split('.')[2]) + 1}"
+
+print()
+print(f"Actions Prefect Deploy's next version will be {version}")
+print()
+
+print()
+print("The new release is ready at:")
+print()
+subprocess.check_call(
+    [
+        "gh",
+        "release",
+        "create",
+        "--title",
+        version,
+        "--generate-notes",
+        "--target",
+        new_revision,
+        version,
+        "--latest"
+    ],
+)
+print()

--- a/scripts/release
+++ b/scripts/release
@@ -21,6 +21,8 @@ with tempfile.TemporaryDirectory() as temporary:
         version = f"{latest_version.split('.')[0]}.{int(latest_version.split('.')[1]) + 1}.0"
     elif release_type == "patch":
         version = f"{latest_version.split('.')[0]}.{latest_version.split('.')[1]}.{int(latest_version.split('.')[2]) + 1}"
+    else:
+        raise ValueError(f"Invalid release type: {release_type}")
 
 print()
 print(f"Actions Prefect Deploy's next version will be {version}")


### PR DESCRIPTION
- Resolves: https://linear.app/prefect/issue/PLA-800/actions-prefect-deploy-add-release-script-to-automatically-bump-the
- Updates GHA to not set the major version of the release (i.e v4) as the "latest" release as we use releases to determine version bumps.  Also generally it seems that other [GHA use the minor/patches as the latest releases](https://github.com/actions/setup-java/releases/tag/v4.5.0)
- Creates a release script similar to our other release scripts but bumps the semver version based on user input of major, minor, or patch.  I'm happy to separate these into individual functions similar to our other scripts but it didn't feel overly necessary here.