### PR TITLE
Re-enable uv for dependencies

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,12 +48,19 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Set up environment
+      run: uv venv
+      shell: bash
+
     - id: install-local-requirements
       if: ${{ inputs.requirements-file-paths != '' }}
       run: |
         IFS=',' read -ra requirements_paths <<< "${{ inputs.requirements-file-paths }}"
         for req in ${requirements_paths[@]}; do
-          pip install -r $req
+          uv pip install -r $req
         done
       shell: bash
 
@@ -61,19 +68,19 @@ runs:
       if: ${{ inputs.pyproject-toml-path != '' }}
       run: |
         cd $(dirname ${{ inputs.pyproject-toml-path }})
-        pip install .
+        uv pip install .
       shell: bash
 
     - id: prefect-deploy
       run: |
-        pip install prefect -U "prefect>=3,<4"
+        uv pip install prefect -U "prefect>=3,<4"
         if [ ${{ inputs.all-deployments }} == "true" ];
         then
-          prefect --no-prompt deploy --all --prefect-file "${{ inputs.deployment-file-path }}"
+          uv run prefect --no-prompt deploy --all --prefect-file "${{ inputs.deployment-file-path }}"
         else
           IFS=',' read -ra deployment_names <<< "${{ inputs.deployment-names }}"
           for name in "${deployment_names[@]}"; do
-            prefect --no-prompt deploy --prefect-file "${{ inputs.deployment-file-path }}" --name "$name"
+            uv run prefect --no-prompt deploy --prefect-file "${{ inputs.deployment-file-path }}" --name "$name"
           done
         fi
       shell: bash

--- a/examples/actions/install-deps-via-pyproject.yaml
+++ b/examples/actions/install-deps-via-pyproject.yaml
@@ -21,3 +21,6 @@ jobs:
         env:
           PREFECT_API_KEY: ${{ secrets.PREFECT_API_KEY }}
           PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
+          # Optionally include credentials for a private pypi index called "my-index" defined in pyproject.toml
+          UV_INDEX_MY_INDEX_USERNAME: ${{ secrets.MY_INDEX_USERNAME }}
+          UV_INDEX_MY_INDEX_PASSWORD: ${{ secrets.MY_INDEX_PASSWORD }}


### PR DESCRIPTION
Re-enables `uv` dependency handling while updating the `pyproject.toml` example to include usage of a private Pypi index to address issue https://github.com/PrefectHQ/actions-prefect-deploy/issues/64.

Un-reverts https://github.com/PrefectHQ/actions-prefect-deploy/pull/57